### PR TITLE
Feat/path 경로 생성하는 유틸리티 함수

### DIFF
--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,16 +1,59 @@
 const PATH = {
-  rootPage: '/',
-  saveTreePage: '/save',
-  reviewPage: 'review',
-  mainPage: '/main',
-  searchPage: '/search',
-  treeInfoPage: '/treeinfo',
-  registInfoPage: '/regist',
-  loginPage: '/login',
-  myPage: '/my',
-  errorPage: '/error',
-  savePage: '/save',
-  redirectPage: '/oauth/redirect*',
-} as const;
+  landingPage: '',
+
+  mainPage: {
+    root: 'main',
+
+    children: {
+      search: 'search',
+    },
+  },
+
+  loginPage: {
+    root: 'login',
+
+    children: {
+      redirect: 'redirect',
+      profileSetting: 'setting',
+    },
+  },
+
+  treePage: {
+    root: 'tree',
+
+    children: {
+      regist: 'regist',
+      dynamicParam: ':treeId',
+
+      review: {
+        root: 'review',
+        dynamicParam: ':reviewId',
+        children: {
+          regist: 'regist',
+          edit: 'edit',
+        },
+      },
+    },
+  },
+
+  registPage: {
+    root: 'regist',
+
+    children: {
+      map: 'map',
+      detail: 'detail',
+    },
+  },
+
+  myPage: {
+    root: 'my',
+
+    children: {
+      registedReviews: 'review',
+      savedTrees: 'save',
+      registedTrees: 'tree',
+    },
+  },
+};
 
 export default PATH;

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -3,7 +3,6 @@ const PATH = {
 
   mainPage: {
     root: 'main',
-
     children: {
       search: 'search',
     },
@@ -11,7 +10,6 @@ const PATH = {
 
   loginPage: {
     root: 'login',
-
     children: {
       redirect: 'redirect',
       profileSetting: 'setting',
@@ -20,34 +18,29 @@ const PATH = {
 
   treePage: {
     root: 'tree',
-
     children: {
-      regist: 'regist',
       dynamicParam: ':treeId',
-
-      review: {
-        root: 'review',
-        dynamicParam: ':reviewId',
+      regist: {
+        root: 'regist',
         children: {
-          regist: 'regist',
-          edit: 'edit',
+          map: 'map',
+          detail: 'detail',
         },
       },
     },
   },
 
-  registPage: {
-    root: 'regist',
-
+  reviewPage: {
+    root: 'review',
+    dynamicParam: ':reviewId',
     children: {
-      map: 'map',
-      detail: 'detail',
+      regist: 'regist',
+      edit: 'edit',
     },
   },
 
   myPage: {
     root: 'my',
-
     children: {
       registedReviews: 'review',
       savedTrees: 'save',

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,108 +1,92 @@
-import React from 'react';
+import { useRoutes, RouteObject, Outlet } from 'react-router-dom';
 import { MainPage } from 'pages/MainPage';
 import { SearchPage } from 'pages/SearchPage';
 import { TreeInfo } from 'pages/TreeInfo';
 import { SignIn } from 'pages/SignIn/SocialLogin';
 import { MyPage } from 'pages/MyPage';
-import { ErrorPage } from 'pages/ErrorPage';
-import { useRoutes, RouteObject, Outlet } from 'react-router-dom';
+import { LandingPage } from 'pages/LandingPage';
 import PATH from 'constants/path';
+import SearchLocation from 'pages/TreeRegi/Search';
 import Redirect from 'pages/SignIn/Redirect';
-import LocationMap from 'pages/TreeRegi/Map';
-import LocationSearch from 'pages/TreeRegi/Search';
+import ReviewDetailPage from 'pages/ReviewDetailPage';
+import RegistMap from 'pages/TreeRegi/Map';
 import TreeRegiDetail from 'pages/TreeRegi/Form';
 import Nickname from 'pages/SignIn/ProfileSetting';
-import ReviewDetailPage from 'pages/ReviewDetailPage';
+import SavePage from 'pages/SavePage';
+import RegistedTreePage from 'pages/RegistedPage';
+import RegistReviewPage from 'pages/RegistedReviewPage';
 
 export const Router = () => {
-  const rootRoutes: RouteObject = {
-    path: PATH.rootPage,
+  const landingRoute: RouteObject = {
+    path: PATH.landingPage,
+    element: <LandingPage />,
+  };
+
+  const mainRoute: RouteObject = {
+    path: PATH.mainPage.root,
     element: <Outlet />,
-    children: [{ path: ':treeId', element: <ReviewDetailPage /> }],
+    children: [
+      { path: '', element: <MainPage /> },
+      { path: PATH.mainPage.children.search, element: <SearchPage /> },
+    ],
   };
 
-  const mainRoutes: RouteObject = {
-    path: PATH.mainPage,
-    element: <MainPage />,
-  };
-
-  const searchRoutes: RouteObject = {
-    path: PATH.searchPage,
-    element: <SearchPage />,
-  };
-
-  const treeInfoRoutes: RouteObject = {
-    path: PATH.treeInfoPage,
-    element: <TreeInfo />,
-  };
-
-  const registRouteObject = {
-    search: {
-      path: 'search',
-      element: <LocationSearch />,
-    },
-
-    map: {
-      path: 'map',
-      element: <LocationMap />,
-    },
-
-    detail: {
-      path: 'detail',
-      element: <TreeRegiDetail />,
-    },
-  };
-
-  const registInfoRoutes: RouteObject = {
-    path: `${PATH.registInfoPage}/*`,
+  const loginRoute: RouteObject = {
+    path: PATH.loginPage.root,
     element: <Outlet />,
-    children: Object.values(registRouteObject),
+    children: [
+      { path: '', element: <SignIn /> },
+      { path: PATH.loginPage.children.profileSetting, element: <Nickname /> },
+      { path: PATH.loginPage.children.redirect, element: <Redirect /> },
+    ],
   };
 
-  const loginRouteObject = {
-    outlet: {
-      path: '',
-      element: <SignIn />,
-    },
-
-    setting: {
-      path: 'setting',
-      element: <Nickname />,
-    },
-  };
-
-  const loginRoutes: RouteObject = {
-    path: PATH.loginPage,
+  const treeRoute: RouteObject = {
+    path: `${PATH.treePage.root}/*`,
     element: <Outlet />,
-    children: Object.values(loginRouteObject),
+    // TreeInfo 컴포넌트 내부에서, state 데이터를 받아서 처리
+    // 언제 동적 파라미터를 사용하고, 언제 useLocation의 state를 사용하면 좋은지?
+    // useLocation의 state를 사용하면 복잡한 데이터를 다시 로드하지 않아도 됨.
+    // 그런데 이런 경우에 공유하기 기능을 사용할 수 없을 것 같아요. 외부에서 진입하면 데이터가 없음
+    children: [
+      { path: PATH.treePage.children.dynamicParam, element: <TreeInfo /> },
+      {
+        path: PATH.treePage.children.regist.root,
+        element: <Outlet />,
+        children: [
+          { path: '', element: <SearchLocation /> },
+          { path: PATH.treePage.children.regist.children.map, element: <RegistMap /> },
+          { path: PATH.treePage.children.regist.children.detail, element: <TreeRegiDetail /> },
+        ],
+      },
+    ],
   };
 
-  const myRoutes: RouteObject = {
-    path: PATH.myPage,
-    element: <MyPage />,
+  const reviewRoute: RouteObject = {
+    path: PATH.reviewPage.root,
+    element: <Outlet />,
+    children: [
+      { path: PATH.reviewPage.dynamicParam, element: <ReviewDetailPage /> },
+      // 리뷰 등록/수정에 트리 아이디 혹은 리뷰 아이디가 필요한데 동적으로 매칭할지, state에 담아서 보낼지?
+      // 리뷰 등록 페이지
+      { path: `${PATH.reviewPage.children.regist}/:treeId`, element: null },
+      // 리뷰 수정 페이지
+      { path: `${PATH.reviewPage.children.edit}/:reviewId`, element: null },
+    ],
   };
 
-  const errorRoutes: RouteObject = {
-    path: PATH.errorPage,
-    element: <ErrorPage />,
+  const myRoute: RouteObject = {
+    path: PATH.myPage.root,
+    element: <Outlet />,
+    children: [
+      { path: '', element: <MyPage /> },
+      { path: PATH.myPage.children.savedTrees, element: <SavePage /> },
+      { path: PATH.myPage.children.registedTrees, element: <RegistedTreePage /> },
+      { path: PATH.myPage.children.registedReviews, element: <RegistReviewPage /> },
+    ],
   };
 
-  const redirectdRoute: RouteObject = {
-    path: PATH.redirectPage,
-    element: <Redirect />,
-  };
-
-  const routes = [
-    rootRoutes,
-    mainRoutes,
-    searchRoutes,
-    treeInfoRoutes,
-    registInfoRoutes,
-    loginRoutes,
-    myRoutes,
-    errorRoutes,
-    redirectdRoute,
-  ];
+  const routes = [landingRoute, mainRoute, treeRoute, reviewRoute, loginRoute, myRoute];
 
   return useRoutes(routes);
 };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -42,7 +42,7 @@ export const Router = () => {
   };
 
   const treeRoute: RouteObject = {
-    path: `${PATH.treePage.root}/*`,
+    path: PATH.treePage.root,
     element: <Outlet />,
     children: [
       { path: PATH.treePage.children.dynamicParam, element: <TreeInfo /> },

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -44,10 +44,6 @@ export const Router = () => {
   const treeRoute: RouteObject = {
     path: `${PATH.treePage.root}/*`,
     element: <Outlet />,
-    // TreeInfo 컴포넌트 내부에서, state 데이터를 받아서 처리
-    // 언제 동적 파라미터를 사용하고, 언제 useLocation의 state를 사용하면 좋은지?
-    // useLocation의 state를 사용하면 복잡한 데이터를 다시 로드하지 않아도 됨.
-    // 그런데 이런 경우에 공유하기 기능을 사용할 수 없을 것 같아요. 외부에서 진입하면 데이터가 없음
     children: [
       { path: PATH.treePage.children.dynamicParam, element: <TreeInfo /> },
       {
@@ -67,7 +63,6 @@ export const Router = () => {
     element: <Outlet />,
     children: [
       { path: PATH.reviewPage.dynamicParam, element: <ReviewDetailPage /> },
-      // 리뷰 등록/수정에 트리 아이디 혹은 리뷰 아이디가 필요한데 동적으로 매칭할지, state에 담아서 보낼지?
       // 리뷰 등록 페이지
       { path: `${PATH.reviewPage.children.regist}/:treeId`, element: null },
       // 리뷰 수정 페이지

--- a/src/utils/createPath.ts
+++ b/src/utils/createPath.ts
@@ -17,8 +17,7 @@ const PATH_DATABASE = {
   },
 
   treePage: {
-    // 트리 상세 페이지는 데이터를 useLocation의 state로 전달하는건지?
-    detail: PATH.treePage.root,
+    detail: (treeId: number) => `${PATH.treePage.root}/${treeId}`,
     regist: {
       search: `${PATH.treePage.root}/${PATH.treePage.children.regist.root}`,
       map: `${PATH.treePage.root}/${PATH.treePage.children.regist.root}/${PATH.treePage.children.regist.children.map}`,
@@ -43,6 +42,7 @@ const PATH_DATABASE = {
 };
 
 type PATH_DATABASE = typeof PATH_DATABASE;
+// 제네릭의 인자가 객체라면 객체의 키를 입력하도록 하는 옵셔널 타입
 type IfObjectThenRequire<T> = T extends object ? keyof T : never;
 
 type CreatePath = {
@@ -73,14 +73,17 @@ const createPath: CreatePath = <
   d1?: D1,
   d2?: D2,
 ) => {
-  if (d1) {
-    if (d2) {
-      return PATH_DATABASE[p][d1][d2];
-    }
+  const page = PATH_DATABASE[p];
 
-    return PATH_DATABASE[p][d1];
+  if (d1 && d2) {
+    return page[d1][d2];
   }
-  return PATH_DATABASE[p];
+
+  if (d1) {
+    return page[d1];
+  }
+
+  return page;
 };
 
 export default createPath;

--- a/src/utils/createPath.ts
+++ b/src/utils/createPath.ts
@@ -17,17 +17,21 @@ const PATH_DATABASE = {
   },
 
   treePage: {
-    detail: (treeId: number) => `${PATH.treePage.root}/${treeId}`,
-    regist: `${PATH.treePage.root}/${PATH.treePage.children.regist}`,
-
-    review: {
-      detail: (treeId: number, reviewId: number) =>
-        `${PATH.treePage.root}/${treeId}/${PATH.treePage.children.review}/${reviewId}`,
-      regist: (treeId: number) =>
-        `${PATH.treePage.root}/${treeId}/${PATH.treePage.children.review}/${PATH.treePage.children.review.children.regist}`,
-      edit: (treeId: number) =>
-        `${PATH.treePage.root}/${treeId}/${PATH.treePage.children.review}/${PATH.treePage.children.review.children.edit}`,
+    // 트리 상세 페이지는 데이터를 useLocation의 state로 전달하는건지?
+    detail: PATH.treePage.root,
+    regist: {
+      search: `${PATH.treePage.root}/${PATH.treePage.children.regist.root}`,
+      map: `${PATH.treePage.root}/${PATH.treePage.children.regist.root}/${PATH.treePage.children.regist.children.map}`,
+      detail: `${PATH.treePage.root}/${PATH.treePage.children.regist.root}/${PATH.treePage.children.regist.children.detail}`,
     },
+  },
+
+  reviewPage: {
+    detail: (reviewId: number) => `${PATH.reviewPage.root}/${reviewId}`,
+    regist: (treeId: number) =>
+      `${PATH.reviewPage.root}/${PATH.reviewPage.children.regist}/${treeId}`,
+    edit: (reviewId: number) =>
+      `${PATH.reviewPage.root}/${PATH.reviewPage.children.edit}/${reviewId}`,
   },
 
   myPage: {

--- a/src/utils/createPath.ts
+++ b/src/utils/createPath.ts
@@ -1,0 +1,82 @@
+import PATH from 'constants/path';
+
+const PATH_DATABASE = {
+  landingPage: {
+    root: PATH.landingPage,
+  },
+
+  mainPage: {
+    root: PATH.mainPage.root,
+    search: `${PATH.mainPage.root}/${PATH.mainPage.children.search}`,
+  },
+
+  loginPage: {
+    root: PATH.loginPage.root,
+    redirect: PATH.loginPage.children.redirect,
+    profileSetting: PATH.loginPage.children.profileSetting,
+  },
+
+  treePage: {
+    detail: (treeId: number) => `${PATH.treePage.root}/${treeId}`,
+    regist: `${PATH.treePage.root}/${PATH.treePage.children.regist}`,
+
+    review: {
+      detail: (treeId: number, reviewId: number) =>
+        `${PATH.treePage.root}/${treeId}/${PATH.treePage.children.review}/${reviewId}`,
+      regist: (treeId: number) =>
+        `${PATH.treePage.root}/${treeId}/${PATH.treePage.children.review}/${PATH.treePage.children.review.children.regist}`,
+      edit: (treeId: number) =>
+        `${PATH.treePage.root}/${treeId}/${PATH.treePage.children.review}/${PATH.treePage.children.review.children.edit}`,
+    },
+  },
+
+  myPage: {
+    root: PATH.myPage.root,
+    savedTrees: `${PATH.myPage.root}/${PATH.myPage.children.savedTrees}`,
+    registedTrees: `${PATH.myPage.root}/${PATH.myPage.children.registedTrees}`,
+    registedReviews: `${PATH.myPage.root}/${PATH.myPage.children.registedReviews}`,
+  },
+};
+
+type PATH_DATABASE = typeof PATH_DATABASE;
+type IfObjectThenRequire<T> = T extends object ? keyof T : never;
+
+type CreatePath = {
+  <P extends keyof PATH_DATABASE>(p: P): PATH_DATABASE[P];
+
+  <P extends keyof PATH_DATABASE, D1 extends keyof PATH_DATABASE[P]>(
+    p: P,
+    d1: D1,
+  ): PATH_DATABASE[P][D1];
+
+  <
+    P extends keyof PATH_DATABASE,
+    D1 extends keyof PATH_DATABASE[P],
+    D2 extends IfObjectThenRequire<PATH_DATABASE[P][D1]>,
+  >(
+    p: P,
+    d1: D1,
+    d2: D2,
+  ): PATH_DATABASE[P][D1][D2];
+};
+
+const createPath: CreatePath = <
+  P extends keyof PATH_DATABASE,
+  D1 extends keyof PATH_DATABASE[P],
+  D2 extends IfObjectThenRequire<PATH_DATABASE[P][D1]>,
+>(
+  p: P,
+  d1?: D1,
+  d2?: D2,
+) => {
+  if (d1) {
+    if (d2) {
+      return PATH_DATABASE[p][d1][d2];
+    }
+
+    return PATH_DATABASE[p][d1];
+  }
+  return PATH_DATABASE[p];
+};
+
+export default createPath;

--- a/src/utils/getPath.ts
+++ b/src/utils/getPath.ts
@@ -2,42 +2,42 @@ import PATH from 'constants/path';
 
 const PATH_DATABASE = {
   landingPage: {
-    root: PATH.landingPage,
+    root: `/${PATH.landingPage}`,
   },
 
   mainPage: {
-    root: PATH.mainPage.root,
+    root: `/${PATH.mainPage.root}`,
     search: `${PATH.mainPage.root}/${PATH.mainPage.children.search}`,
   },
 
   loginPage: {
-    root: PATH.loginPage.root,
-    redirect: PATH.loginPage.children.redirect,
-    profileSetting: PATH.loginPage.children.profileSetting,
+    root: `/${PATH.loginPage.root}`,
+    redirect: `${PATH.loginPage.children.redirect}`,
+    profileSetting: `${PATH.loginPage.children.profileSetting}`,
   },
 
   treePage: {
-    detail: (treeId: number) => `${PATH.treePage.root}/${treeId}`,
+    detail: (treeId: number) => `/${PATH.treePage.root}/${treeId}`,
     regist: {
-      search: `${PATH.treePage.root}/${PATH.treePage.children.regist.root}`,
-      map: `${PATH.treePage.root}/${PATH.treePage.children.regist.root}/${PATH.treePage.children.regist.children.map}`,
-      detail: `${PATH.treePage.root}/${PATH.treePage.children.regist.root}/${PATH.treePage.children.regist.children.detail}`,
+      search: `/${PATH.treePage.root}/${PATH.treePage.children.regist.root}`,
+      map: `/${PATH.treePage.root}/${PATH.treePage.children.regist.root}/${PATH.treePage.children.regist.children.map}`,
+      detail: `/${PATH.treePage.root}/${PATH.treePage.children.regist.root}/${PATH.treePage.children.regist.children.detail}`,
     },
   },
 
   reviewPage: {
-    detail: (reviewId: number) => `${PATH.reviewPage.root}/${reviewId}`,
+    detail: (reviewId: number) => `/${PATH.reviewPage.root}/${reviewId}`,
     regist: (treeId: number) =>
-      `${PATH.reviewPage.root}/${PATH.reviewPage.children.regist}/${treeId}`,
+      `/${PATH.reviewPage.root}/${PATH.reviewPage.children.regist}/${treeId}`,
     edit: (reviewId: number) =>
-      `${PATH.reviewPage.root}/${PATH.reviewPage.children.edit}/${reviewId}`,
+      `/${PATH.reviewPage.root}/${PATH.reviewPage.children.edit}/${reviewId}`,
   },
 
   myPage: {
-    root: PATH.myPage.root,
-    savedTrees: `${PATH.myPage.root}/${PATH.myPage.children.savedTrees}`,
-    registedTrees: `${PATH.myPage.root}/${PATH.myPage.children.registedTrees}`,
-    registedReviews: `${PATH.myPage.root}/${PATH.myPage.children.registedReviews}`,
+    root: `/${PATH.myPage.root}`,
+    savedTrees: `/${PATH.myPage.root}/${PATH.myPage.children.savedTrees}`,
+    registedTrees: `/${PATH.myPage.root}/${PATH.myPage.children.registedTrees}`,
+    registedReviews: `/${PATH.myPage.root}/${PATH.myPage.children.registedReviews}`,
   },
 };
 

--- a/src/utils/getPath.ts
+++ b/src/utils/getPath.ts
@@ -1,9 +1,7 @@
 import PATH from 'constants/path';
 
 const PATH_DATABASE = {
-  landingPage: {
-    root: `/${PATH.landingPage}`,
-  },
+  landingPage: `/${PATH.landingPage}`,
 
   mainPage: {
     root: `/${PATH.mainPage.root}`,

--- a/src/utils/getPath.ts
+++ b/src/utils/getPath.ts
@@ -45,7 +45,7 @@ type PATH_DATABASE = typeof PATH_DATABASE;
 // 제네릭의 인자가 객체라면 객체의 키를 입력하도록 하는 옵셔널 타입
 type IfObjectThenRequire<T> = T extends object ? keyof T : never;
 
-type CreatePath = {
+type GetPath = {
   <P extends keyof PATH_DATABASE>(p: P): PATH_DATABASE[P];
 
   <P extends keyof PATH_DATABASE, D1 extends keyof PATH_DATABASE[P]>(
@@ -64,7 +64,7 @@ type CreatePath = {
   ): PATH_DATABASE[P][D1][D2];
 };
 
-const createPath: CreatePath = <
+const getPath: GetPath = <
   P extends keyof PATH_DATABASE,
   D1 extends keyof PATH_DATABASE[P],
   D2 extends IfObjectThenRequire<PATH_DATABASE[P][D1]>,
@@ -86,4 +86,4 @@ const createPath: CreatePath = <
   return page;
 };
 
-export default createPath;
+export default getPath;


### PR DESCRIPTION
## ⭐ 개요
라우트 파일에서 사용할 PATH 상수와, 상수를 기반으로 경로 데이터 혹은 경로를 생성하는 함수를 반환하는 유틸리티 함수를 작성했습니다.

사용 예시
```ts
const path = createPath('mainPage', 'search');
```

위 코드와 같이 사용할 수 있고, 동적으로 데이터가 필요한 경우에는 함수 형태로 반환되어서 동적 데이터를 작성해주어야 합니다.
데이터는 매개변수명으로 구체화 시켜 적어두었으니 컴파일러 확인하시면서 사용하시면 크게 어렵지 않을겁니다.
궁금한 점이 더 있으시면 리뷰 혹은 디스코드 DM으로 질문 주세요!

```ts
const path1 = createPath('treePage', 'detail');
path1(123);
```

## 📋 진행 사항
- [x] 상수
- [x] 함수 

## 🚀 반영 브랜치
feat/path -> develop

close #38 
