### PR TITLE
Feat/image 관련 기능 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "axios": "^1.6.2",
+        "browser-image-compression": "^2.0.2",
         "react": "^18.2.0",
         "react-date-range": "^2.0.0-alpha.4",
         "react-dom": "^18.2.0",
@@ -5968,6 +5969,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -17848,6 +17857,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
@@ -22982,6 +22996,14 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "requires": {
+        "uzip": "0.20201231.0"
       }
     },
     "browser-process-hrtime": {
@@ -31308,6 +31330,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "v8-to-istanbul": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "axios": "^1.6.2",
+    "browser-image-compression": "^2.0.2",
     "react": "^18.2.0",
     "react-date-range": "^2.0.0-alpha.4",
     "react-dom": "^18.2.0",

--- a/src/hooks/usePreviewImage.ts
+++ b/src/hooks/usePreviewImage.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+const usePreviewImage = (imageFile: File | null) => {
+  const [imageSrc, setImageSrc] = useState('');
+
+  useEffect(() => {
+    const reader = new FileReader();
+
+    if (imageFile) {
+      reader.onloadend = () => {
+        setImageSrc(reader.result as string);
+      };
+
+      reader.readAsDataURL(imageFile);
+    }
+
+    return () => {
+      reader.abort();
+    };
+  }, [imageFile]);
+
+  return imageSrc;
+};
+
+export default usePreviewImage;

--- a/src/utils/imageUtils/convertImageFileToUrl.ts
+++ b/src/utils/imageUtils/convertImageFileToUrl.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+import imageCompression from 'browser-image-compression';
+import { HTTPError } from 'error/HTTPError';
+
+type ImageCompressionOptions = Parameters<typeof imageCompression>['1'];
+
+type ImageUrl = string;
+
+type ImageUploadResponse = {
+  imageUrl: ImageUrl;
+};
+
+const convertImageFileToUrl = async (
+  imageFile: File,
+  compressionOptions?: ImageCompressionOptions,
+): Promise<ImageUrl> => {
+  const formData = new FormData();
+  const compressedImageFile = await imageCompression(imageFile, {
+    maxSizeMB: 0.2,
+    ...compressionOptions,
+  });
+  formData.append('file', compressedImageFile);
+
+  try {
+    const response = await axios<ImageUploadResponse>(
+      `${process.env.REACT_APP_TREE_API_URL}v1/images/upload`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'multipart/formdata',
+        },
+        data: formData,
+      },
+    );
+
+    return response.data.imageUrl;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      throw new HTTPError('사진을 등록하던 도중 오류가 발생했습니다.', error.status);
+    }
+
+    throw new Error('사진을 등록하던 도중 알 수 없는 오류가 발생했습니다.');
+  }
+};
+
+export default convertImageFileToUrl;


### PR DESCRIPTION
## ⭐ 개요
이미지 파일을 올려 html에서 미리볼 수 있는 형식으로 변환하는 기능과 이미지 파일을 S3에 업로드해 URL로 반환받는 함수 개발 완료했습니다.

## 사용 예시
### usePreviewImage

File 형식의 이미지 데이터를 넘겨 image source 형식의 상태를 반환하는 커스텀 훅입니다.

#### Parameters

usePreviewImage는 1개의 인자를 받습니다.

- imageFile
    
    `null` 또는 `File` 인터페이스를 가진 객체입니다. 
    

#### Usage

`imageFile`이라는 상태를 선언해 해당 상태를 `usePreviewImage` 커스텀 훅에 전달하고 `img` 태그에 해당 커스텀 훅이 반환하는 source를 전달하면 미리보기 이미지를 사용할 수 있습니다.

```tsx
function ProfileImageSetting() {
  const [imageFile, setImageFile] = useState<File | null>(null);
  const privewImage = usePreviewImage(imageFile);

  const handleImageChange = (input: EventTarget & HTMLInputElement) => {
    if (input.files && input.files[0]) {
      setImageFile(input.files[0]);
    }
  };

  return (
    <>
      <S.ImageInput
        type="file"
        accept="image/*"
        alt="프로필 이미지"
        className="hidden"
        ref={imageInputRef}
        onChange={(e) => {
          handleImageChange(e.target);
        }}
      />
      <ProfileImage src={privewImage} onClick={handleImageClick} />
    </>
  );
}

export default ProfileImageSetting;
```

### convertImageFileToUrl

File 형식의 이미지 데이터를 넘겨 image URL을 반환받는 함수입니다.

#### Parameters

- imageFile
    
    `null` 또는 `File` 인터페이스를 가진 객체입니다. 
    
- compressionOptions
    
    `browser-image-compression` 라이브러리의 `imageCompression` 함수에 전달되는 이미지 압축을 위한 옵션들입니다. 아래 정리된 옵션들을 참고해 옵션을 작성하시면 될 것 같아요. 
    
    기본적으로 `maxSizeMB` 옵션은 200 바이트로 지정되어 있어요. 
    
    ```tsx
    // maxSizeMB, maxWidthOrHeight 중 하나를 옵션에 제공해야 합니다.
    const options: Options = { 
      maxSizeMB: number,            // (기본값: Number.POSITIVE_INFINITY) 최대 파일 크기(MB 단위)
      maxWidthOrHeight: number,     // (기본값: undefined) 압축된 파일이 비율에 따라 축소되어, 너비 또는 높이가 maxWidthOrHeight보다 작아집니다.
                                    // 그러나, 자동으로 각 브라우저에서 지원하는 최대 Canvas 크기보다 작게 축소됩니다.
                                    // 자세한 내용은 Caveat 부분을 확인해주세요.
      onProgress: Function,         // (선택사항) 진행 상황을 나타내는 함수, 0에서 100까지의 진행률을 인자로 받습니다.
      useWebWorker: boolean,        // (선택사항) 멀티 스레드 웹 워커를 사용, 웹 워커를 사용할 수 없을 경우 메인 스레드에서 실행 (기본값: true)
      libURL: string,               // (선택사항) 이 라이브러리의 libURL로, 웹 워커에서 스크립트를 가져오는데 사용 (기본값: https://cdn.jsdelivr.net/npm/browser-image-compression/dist/browser-image-compression.js)
      preserveExif: boolean,        // (선택사항) JPEG 이미지의 Exif 메타데이터를 보존합니다. 예: 카메라 모델, 초점 거리 등 (기본값: false)
    
      signal: AbortSignal,          // (선택사항) 압축을 중단/취소하기 위한 신호
    
      // 고급 옵션들입니다.
      maxIteration: number,         // (선택사항) 이미지를 압축하는 최대 반복 횟수 (기본값: 10)
      exifOrientation: number,      // (선택사항) https://stackoverflow.com/a/32490603/10395024 참조
      fileType: string,             // (선택사항) 파일 타입을 지정합니다. 예: 'image/jpeg', 'image/png' (기본값: file.type)
      initialQuality: number,       // (선택사항) 초기 품질 값은 0과 1 사이 (기본값: 1)
      alwaysKeepResolution: boolean // (선택사항) 품질만 줄이고, 항상 너비와 높이를 유지합니다. (기본값: false)
    }
    ```

## 📋 진행 사항
- [x] usePreivewImage
- [x] convertImageFileToUrl

## 🚀 반영 브랜치
feat/image -> develop

close #72 
