### PR TITLE
Hotfix/v0.1.2-beta

### DIFF
--- a/src/components/SaveButton/index.tsx
+++ b/src/components/SaveButton/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useRef, useState } from 'react';
 import saveIcon from 'assets/save-icon.svg';
 import fullSaveIcon from 'assets/full-save-icon.svg';
 import useApiMutation from 'hooks/useApiMutation';
@@ -7,9 +8,10 @@ import * as S from './style';
 interface ISaveButtonProps {
   treeId: number;
   isFavorite: boolean;
+  onSaved?: () => void;
 }
 
-const SaveButton = ({ treeId, isFavorite: initialIsFavorite }: ISaveButtonProps) => {
+const SaveButton = ({ treeId, isFavorite: initialIsFavorite, onSaved }: ISaveButtonProps) => {
   const [isFavorite, setIsFavorite] = useState<boolean>(initialIsFavorite);
   const imgSrc = isFavorite ? fullSaveIcon : saveIcon;
 
@@ -18,9 +20,20 @@ const SaveButton = ({ treeId, isFavorite: initialIsFavorite }: ISaveButtonProps)
     'POST',
   );
 
+  React.useEffect(() => {
+    setIsFavorite(initialIsFavorite);
+  }, [treeId]);
+
   const handleSaveButton = () => {
     setIsFavorite((prev) => !prev);
-    mutate({ treeId, isFavorite: !isFavorite });
+    mutate(
+      { treeId, isFavorite: !isFavorite },
+      {
+        onSuccess: () => {
+          if (onSaved) onSaved();
+        },
+      },
+    );
   };
 
   return (

--- a/src/hooks/useApiMutation.ts
+++ b/src/hooks/useApiMutation.ts
@@ -1,14 +1,14 @@
 import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 import axios, { AxiosResponse } from 'axios';
 import { HTTPError } from 'error/HTTPError';
-import useUser from './useUser';
+import { useToken } from './useUser';
 
 const useApiMutation = <TData = unknown, TVariables = unknown>(
   url: string,
   method: 'POST' | 'PUT' | 'DELETE',
   options?: UseMutationOptions<TData, Error, TVariables, unknown>,
 ) => {
-  const { token } = useUser();
+  const token = useToken();
 
   const mutationFn = async (variables: TVariables): Promise<TData> => {
     try {

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,13 +1,13 @@
 import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import axios, { AxiosResponse } from 'axios';
 import { HTTPError } from 'error/HTTPError';
-import useUser from './useUser';
+import { useToken } from './useUser';
 
 const useApiQuery = <TData = unknown>(
   queryParam: string,
   enabled?: boolean,
 ): UseQueryResult<TData, Error> => {
-  const { token } = useUser();
+  const token = useToken();
 
   const fetchData = async () => {
     try {

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,6 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { HTTPError } from 'error/HTTPError';
+import useApiQuery from './useApiQuery';
+
+const localStorageTokenKey = 'token';
 
 const deleteUser = async (token: string) => {
   const res = await axios({
@@ -15,9 +18,7 @@ const deleteUser = async (token: string) => {
   return res;
 };
 
-const useUser = () => {
-  const localStorageKey = 'token';
-  const token = sessionStorage.getItem(localStorageKey);
+const useWithraw = (token: string) => {
   const { mutate } = useMutation({ mutationFn: deleteUser });
 
   const withraw = () => {
@@ -32,15 +33,35 @@ const useUser = () => {
     }
   };
 
+  return withraw;
+};
+
+const useIsLogin = () => {
+  const { isError } = useApiQuery('v1/my');
+
+  if (isError) {
+    return false;
+  }
+
+  return true;
+};
+
+export const useToken = () => sessionStorage.getItem(localStorageTokenKey);
+
+const useUser = () => {
+  const token = useToken();
+  const isLogin = useIsLogin();
+  const withraw = useWithraw(token ?? '');
+
   const login = (accessToken: string) => {
-    sessionStorage.setItem(localStorageKey, accessToken);
+    sessionStorage.setItem(localStorageTokenKey, accessToken);
   };
 
   const logout = () => {
-    sessionStorage.removeItem(localStorageKey);
+    sessionStorage.removeItem(localStorageTokenKey);
   };
 
-  return { token, login, logout, isLogin: !!token, withraw };
+  return { login, logout, isLogin, withraw };
 };
 
 export default useUser;

--- a/src/pages/MainPage/components/TreeInfoCard/index.tsx
+++ b/src/pages/MainPage/components/TreeInfoCard/index.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import useApiQuery from 'hooks/useApiQuery';
 import TreeLocationItem from 'components/TreeLocationItem';
 import { HTTPError } from 'error/HTTPError';
+import { useQueryClient } from '@tanstack/react-query';
 import * as S from './style';
 
 interface IProps {
@@ -14,6 +15,7 @@ interface IProps {
 }
 
 const TreeInfoCard = ({ id }: IProps) => {
+  const queryClient = useQueryClient();
   const {
     data: treeInfo,
     isError: isInfoError,
@@ -37,6 +39,12 @@ const TreeInfoCard = ({ id }: IProps) => {
     navigate(`/tree/${id}`);
   };
 
+  const invalidateTreeInfoQuery = () => {
+    queryClient.invalidateQueries({
+      queryKey: [`v1/trees/${id}`],
+    });
+  };
+
   return treeInfo ? (
     <S.Wrapper>
       <S.Title onClick={handleGoToTreeInfo}>
@@ -45,7 +53,11 @@ const TreeInfoCard = ({ id }: IProps) => {
         </TreeLocationItem>
       </S.Title>
       <S.Btns>
-        <SaveButton treeId={id} isFavorite={treeInfo.isFavorite} />
+        <SaveButton
+          treeId={id}
+          isFavorite={treeInfo.isFavorite}
+          onSaved={invalidateTreeInfoQuery}
+        />
         <ShareButton treeId={treeInfo.treeId} treeName={treeInfo.name} />
       </S.Btns>
       <S.Images onClick={handleGoToTreeInfo}>


### PR DESCRIPTION
## ⭐ 개요
베타 버전에 발생한 오류를 수정했습니다.

### 트리 정보 저장하기 상태 오류
![화면 기록 2024-03-21 15 10 53](https://github.com/whereismytree/frontend/assets/126222927/9bc879b4-7133-4560-9bbc-cff682f17616)

`SaveButton` 컴포넌트 내부에서 useEffect hook을 활용해 트리 아이디가 변경될 때 저장하기 상태가 변경되도록 수정해 해결했습니다.

### 두 저장하기 상태가 상이한 오류
![화면 기록 2024-03-21 15 12 38](https://github.com/whereismytree/frontend/assets/126222927/8c333ce3-9d35-4884-b911-b11930adea61)

`SaveButton` 컴포넌트에서 `onSaved`라는 콜백을 통해 저장하기가 끝난 시점에 콜백함수를 받아 처리할 수 있도록 코드를 작성하고, 트리 카드 컴포넌트에서 트리 정보를 받아오는 쿼리를 무효화하여 오류를 수정했습니다.

### 로그인 상태 오류
일정 시간이 경과할 시 사용자 인증 토큰이 만료되는 경우가 있었고, 기존에 `sessionStorage`에 토큰이 존재하는지로 유저의 로그인을 판별했던 부분을 유효한 토큰인지 판별하는 로직으로 수정하여 해결했습니다.
