### PR TITLE
Hotfix/로그인, API 요청 관련 에러 픽스

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: 'checkout branch'
         uses: actions/checkout@v1
         with:
-          ref: main
+          ref: ${{ github.head_ref }}
       - name: 'Npm Install'
         run: npm install
       - name: 'Create env file'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
     types: [closed]
+  push:
+    branches:
+      - hotfix/v0.1.3-beta
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: Build & Deploy React App
 on:
-  push:
-    branches:
-      - hotfix/v0.1.3-beta
   pull_request:
     branches:
       - main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,12 @@
 name: Build & Deploy React App
 on:
+  push:
+    branches:
+      - hotfix/v0.1.3-beta
   pull_request:
     branches:
       - main
     types: [closed]
-  push:
-    branches:
-      - hotfix/v0.1.3-beta
 
 jobs:
   build:

--- a/src/components/FallbackComponent/index.tsx
+++ b/src/components/FallbackComponent/index.tsx
@@ -4,16 +4,11 @@ import Guide from 'components/common/Guide';
 import Topbar from 'components/Topbar';
 import { HTTPError } from 'error/HTTPError';
 import getPath from 'utils/getPath';
-import LoginExpiredGuide from 'components/Guides/LoginExpired';
 import * as S from './style';
 
 const FallbackComponent = ({ error, resetErrorBoundary }: FallbackProps) => {
   const navigate = useNavigate();
   if (error instanceof HTTPError) {
-    if (error.statusCode === 401) {
-      return <LoginExpiredGuide onClick={resetErrorBoundary} />;
-    }
-
     return (
       <>
         <Topbar>{null}</Topbar>

--- a/src/components/Guides/SessionExpired/index.tsx
+++ b/src/components/Guides/SessionExpired/index.tsx
@@ -3,7 +3,7 @@ import Guide from 'components/common/Guide';
 import getPath from 'utils/getPath';
 import Layout from '../Layout';
 
-const LoginExpiredGuide = ({ onClick }: { onClick?: () => void }) => {
+const SessionExpiredGuide = ({ onClick }: { onClick?: () => void }) => {
   const navigate = useNavigate();
 
   return (
@@ -21,4 +21,4 @@ const LoginExpiredGuide = ({ onClick }: { onClick?: () => void }) => {
   );
 };
 
-export default LoginExpiredGuide;
+export default SessionExpiredGuide;

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -47,6 +47,8 @@ const PATH = {
       registedTrees: 'tree',
     },
   },
+
+  sessionExpired: '401',
 };
 
 export default PATH;

--- a/src/hooks/treeHooks.ts
+++ b/src/hooks/treeHooks.ts
@@ -3,14 +3,10 @@ import { ITreeItem } from 'types/apiResponse';
 import useApiQuery from './useApiQuery';
 
 export const useTreeData = (treeId: string) => {
-  const { data, isError, isLoading, error } = useApiQuery<ITreeItem>(`v1/trees/${treeId}`);
+  const { data, isError, isLoading } = useApiQuery<ITreeItem>(`v1/trees/${treeId}`);
 
-  if (isError) {
-    throw new HTTPError(`트리를 불러오는 데 오류가 발생했습니다. ${error}`);
-  }
-
-  if (!isLoading && !data) {
-    throw new Error(`트리 데이터를 받아오는 API 응답값이 올바르지 않습니다. ${data}`);
+  if (!isLoading && isError) {
+    throw new HTTPError(`트리를 불러오는 데 오류가 발생했습니다.`);
   }
 
   return data;

--- a/src/hooks/useApiMutation.ts
+++ b/src/hooks/useApiMutation.ts
@@ -1,6 +1,8 @@
 import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import axios, { AxiosResponse } from 'axios';
 import { HTTPError } from 'error/HTTPError';
+import getPath from 'utils/getPath';
 import { useToken } from './useUser';
 
 const useApiMutation = <TData = unknown, TVariables = unknown>(
@@ -9,11 +11,12 @@ const useApiMutation = <TData = unknown, TVariables = unknown>(
   options?: UseMutationOptions<TData, Error, TVariables, unknown>,
 ) => {
   const token = useToken();
+  const navigate = useNavigate();
 
   const mutationFn = async (variables: TVariables): Promise<TData> => {
     try {
       const response: AxiosResponse<TData> = await axios({
-        url,
+        url: `${process.env.REACT_APP_TREE_API_URL}${url}`,
         method,
         headers: {
           'Content-Type': 'application/json',
@@ -24,6 +27,10 @@ const useApiMutation = <TData = unknown, TVariables = unknown>(
 
       return response.data;
     } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 500) {
+        navigate(getPath('sessionExpired'));
+      }
+
       if (axios.isAxiosError(error) && error.response) {
         throw new HTTPError('axios 통신 중 오류가 발생했습니다.', error.response.status);
       }

--- a/src/hooks/useApiMutation.ts
+++ b/src/hooks/useApiMutation.ts
@@ -13,7 +13,7 @@ const useApiMutation = <TData = unknown, TVariables = unknown>(
   const mutationFn = async (variables: TVariables): Promise<TData> => {
     try {
       const response: AxiosResponse<TData> = await axios({
-        url: `${process.env.REACT_APP_TREE_API_URL}${url}`,
+        url,
         method,
         headers: {
           'Content-Type': 'application/json',

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,6 +1,8 @@
+import { useNavigate } from 'react-router-dom';
 import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import axios, { AxiosResponse } from 'axios';
 import { HTTPError } from 'error/HTTPError';
+import getPath from 'utils/getPath';
 import { useToken } from './useUser';
 
 const useApiQuery = <TData = unknown>(
@@ -8,6 +10,7 @@ const useApiQuery = <TData = unknown>(
   enabled?: boolean,
 ): UseQueryResult<TData, Error> => {
   const token = useToken();
+  const navigate = useNavigate();
 
   const fetchData = async () => {
     try {
@@ -23,6 +26,10 @@ const useApiQuery = <TData = unknown>(
 
       return response.data;
     } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 500) {
+        navigate(getPath('sessionExpired'));
+      }
+
       if (axios.isAxiosError(error) && error.response) {
         throw new HTTPError('axios 통신 중 오류가 발생했습니다.', error.response.status);
       }

--- a/src/hooks/useSnackBar.tsx
+++ b/src/hooks/useSnackBar.tsx
@@ -29,7 +29,7 @@ const showAndSlideUp = keyframes`
 
 const SnackBarUI = styled.span<{ $view: boolean; $during: number }>`
   position: fixed;
-  top: var(--header-height);
+  top: -100%;
   left: 50%;
   transform: translateX(-50%);
   z-index: 100;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { HTTPError } from 'error/HTTPError';
-import useApiQuery from './useApiQuery';
 
 const localStorageTokenKey = 'token';
 
@@ -37,55 +36,16 @@ const useWithraw = (token: string) => {
   return withraw;
 };
 
-export const useToken = () => {
-  const [token, setToken] = useState('');
-
-  useEffect(() => {
-    setToken(sessionStorage.getItem(localStorageTokenKey) || '');
-  });
-
-  return token;
-};
-
-const useTokenExpired = () => {
-  const queryClient = useQueryClient();
-  const { isLoading, data } = useApiQuery('v1/my');
-  const [isExpired, setIsExpired] = useState(false);
-
-  useEffect(() => {
-    if (isLoading) return;
-
-    if (data) {
-      setIsExpired(false);
-    } else {
-      setIsExpired(true);
-    }
-  }, [data]);
-
-  useEffect(() => {
-    queryClient.invalidateQueries({ queryKey: ['v1/my'] });
-  }, []);
-
-  return isExpired;
-};
+export const useToken = () => sessionStorage.getItem(localStorageTokenKey) || '';
 
 const useUser = () => {
   const [isLogin, setIsLogin] = useState(false);
   const token = useToken();
-  const isTokenExpired = useTokenExpired();
   const withraw = useWithraw(token ?? '');
 
   useEffect(() => {
     setIsLogin(Boolean(token));
   });
-
-  useEffect(() => {
-    return () => {
-      if (token && isTokenExpired) {
-        throw new HTTPError('로그인 정보가 만료되었습니다.', 401);
-      }
-    };
-  }, [isTokenExpired]);
 
   const login = (accessToken: string) => {
     sessionStorage.setItem(localStorageTokenKey, accessToken);

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -52,9 +52,9 @@ const useUser = () => {
     }
 
     if (isError) {
-      if (token) {
-        throw new HTTPError('로그인 정보가 만료되었습니다.', 401);
-      }
+      // if (token) {
+      //   throw new HTTPError('로그인 정보가 만료되었습니다.', 401);
+      // }
 
       setIsLogin(false);
     }

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -52,10 +52,6 @@ const useUser = () => {
     }
 
     if (isError) {
-      // if (token) {
-      //   throw new HTTPError('로그인 정보가 만료되었습니다.', 401);
-      // }
-
       setIsLogin(false);
     }
   }, [isLoading, isError]);

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -41,22 +41,24 @@ export const useToken = () => sessionStorage.getItem(localStorageTokenKey);
 
 const useUser = () => {
   const [isLogin, setIsLogin] = useState(false);
-  const { isError } = useApiQuery('v1/my');
+  const { isLoading, isError } = useApiQuery('v1/my');
   const token = useToken();
 
   useEffect(() => {
-    if (token && isError) {
-      throw new HTTPError('로그인 정보가 만료되었습니다.', 401);
-    }
-
-    if (isError) {
-      setIsLogin(false);
-    }
+    if (isLoading) return;
 
     if (!isError) {
       setIsLogin(true);
     }
-  }, [isError]);
+
+    if (isError) {
+      if (token) {
+        throw new HTTPError('로그인 정보가 만료되었습니다.', 401);
+      }
+
+      setIsLogin(false);
+    }
+  }, [isLoading, isError]);
 
   const withraw = useWithraw(token ?? '');
 

--- a/src/pages/LoginPage/SocialLogin/index.tsx
+++ b/src/pages/LoginPage/SocialLogin/index.tsx
@@ -12,7 +12,7 @@ function SignIn() {
       <S.Modal>
         <S.GuideText>
           어쩔트리와 추억을 공유하시려면
-          <br /> 로그인을 해주세요. 버킷 업로드 테스트입니다.
+          <br /> 로그인을 해주세요
         </S.GuideText>
         <S.LoginButtonWrapper>
           <S.LoginButton platform="google" href={googleLoginUrl}>

--- a/src/pages/LoginPage/SocialLogin/index.tsx
+++ b/src/pages/LoginPage/SocialLogin/index.tsx
@@ -12,7 +12,7 @@ function SignIn() {
       <S.Modal>
         <S.GuideText>
           어쩔트리와 추억을 공유하시려면
-          <br /> 로그인을 해주세요.
+          <br /> 로그인을 해주세요. 버킷 업로드 테스트입니다.
         </S.GuideText>
         <S.LoginButtonWrapper>
           <S.LoginButton platform="google" href={googleLoginUrl}>

--- a/src/pages/LoginPage/SocialLogin/index.tsx
+++ b/src/pages/LoginPage/SocialLogin/index.tsx
@@ -12,7 +12,7 @@ function SignIn() {
       <S.Modal>
         <S.GuideText>
           어쩔트리와 추억을 공유하시려면
-          <br /> 로그인을 해주세요
+          <br /> 로그인을 해주세요.
         </S.GuideText>
         <S.LoginButtonWrapper>
           <S.LoginButton platform="google" href={googleLoginUrl}>

--- a/src/pages/MainPage/components/TreeInfoCard/index.tsx
+++ b/src/pages/MainPage/components/TreeInfoCard/index.tsx
@@ -16,23 +16,17 @@ interface IProps {
 
 const TreeInfoCard = ({ id }: IProps) => {
   const queryClient = useQueryClient();
-  const {
-    data: treeInfo,
-    isError: isInfoError,
-    error: infoError,
-  } = useApiQuery<ITreeItem>(`v1/trees/${id}`);
-  const {
-    data: reviewImages,
-    isError: isReviewImagesError,
-    error: reviewImagesError,
-  } = useApiQuery<IReviewImages>(`v1/reviews/images?treeId=${id}`);
+  const { data: treeInfo, isError: isInfoError } = useApiQuery<ITreeItem>(`v1/trees/${id}`);
+  const { data: reviewImages, isError: isReviewImagesError } = useApiQuery<IReviewImages>(
+    `v1/reviews/images?treeId=${id}`,
+  );
   const navigate = useNavigate();
 
   if (isInfoError) {
-    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다. ${infoError}`);
+    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다.`);
   }
   if (isReviewImagesError) {
-    throw new HTTPError(`리뷰 이미지를 불러오는데 오류가 발생했습니다. ${reviewImagesError}`);
+    throw new HTTPError(`리뷰 이미지를 불러오는데 오류가 발생했습니다.`);
   }
 
   const handleGoToTreeInfo = () => {

--- a/src/pages/MyPage/hooks.ts
+++ b/src/pages/MyPage/hooks.ts
@@ -5,12 +5,8 @@ import IUserData from './types';
 export const useProfile = () => {
   const { data, isError, isLoading } = useApiQuery<IUserData>('v1/my');
 
-  if (isError) {
+  if (!data && !isLoading && isError) {
     throw new HTTPError('내 정보를 불러오는 데 오류가 발생했습니다.');
-  }
-
-  if (!data && !isLoading) {
-    throw new HTTPError('불러온 사용자의 프로필 데이터가 존재하지 않습니다.');
   }
 
   return data;

--- a/src/pages/ReviewRegistAndEditPage/index.tsx
+++ b/src/pages/ReviewRegistAndEditPage/index.tsx
@@ -33,13 +33,13 @@ const ReviewRegistAndEditPage = () => {
   const navigate = useNavigate();
   const { open, close, ref: modalRef } = useModal();
 
-  const { data, isError, error } = useApiQuery<IGetReview>(
+  const { data, isError } = useApiQuery<IGetReview>(
     `v1/reviews/${id}?reviewId=${id}`,
     type === 'edit',
   );
 
   if (isError) {
-    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다. ${error}`);
+    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다.`);
   }
 
   const { mutate: registMutate } = useApiMutation<{ reviewId: number }>('v1/reviews', 'POST');

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -9,13 +9,13 @@ import * as S from './style';
 
 export const SearchPage = () => {
   const [keyword, setKeyword] = useState<string>('');
-  const { data, isError, error } = useApiQuery<{ trees: IMainSearchResult[] }>(
+  const { data, isError } = useApiQuery<{ trees: IMainSearchResult[] }>(
     `v1/trees/list?query=${keyword}`,
     keyword !== '',
   );
 
   if (isError) {
-    throw new HTTPError(`검색 결과를 불러오는데 오류가 발생했습니다. ${error}`);
+    throw new HTTPError(`검색 결과를 불러오는데 오류가 발생했습니다.`);
   }
 
   const navigate = useNavigate();

--- a/src/pages/TreeInfoPage/components/TreeDetails/index.tsx
+++ b/src/pages/TreeInfoPage/components/TreeDetails/index.tsx
@@ -9,10 +9,10 @@ interface IProps {
 }
 
 const TreeDetails = ({ treeId }: IProps) => {
-  const { data, isError, error } = useApiQuery<ITreeItem>(`v1/trees/${treeId}`);
+  const { data, isError } = useApiQuery<ITreeItem>(`v1/trees/${treeId}`);
 
   if (isError) {
-    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다. ${error}`);
+    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다.`);
   }
 
   // 전시기간을 형식에 맞게 포맷팅하는 함수

--- a/src/pages/TreeInfoPage/components/TreeTitle/index.tsx
+++ b/src/pages/TreeInfoPage/components/TreeTitle/index.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import TreeLocationItem from 'components/TreeLocationItem';
 import SaveButton from 'components/SaveButton';
 import ShareButton from 'components/ShareButton';
-import { ITreeItem } from 'types/apiResponse';
-import useApiQuery from 'hooks/useApiQuery';
-import { HTTPError } from 'error/HTTPError';
+import { useTreeData } from 'hooks/treeHooks';
 import * as S from '../style';
 
 interface IProps {
@@ -12,11 +10,7 @@ interface IProps {
 }
 
 const TreeTitle = ({ treeId }: IProps) => {
-  const { data, isError, error } = useApiQuery<ITreeItem>(`v1/trees/${treeId}`);
-
-  if (isError) {
-    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다. ${error}`);
-  }
+  const data = useTreeData(String(treeId));
 
   return data ? (
     <S.Title>

--- a/src/pages/TreeInfoPage/components/VisitorPhotoList/index.tsx
+++ b/src/pages/TreeInfoPage/components/VisitorPhotoList/index.tsx
@@ -12,11 +12,11 @@ interface IProps {
 }
 
 const VisitorPhotoList = ({ treeId, treeInfo }: IProps) => {
-  const { data, isError, error } = useApiQuery<IReviewImages>(`v1/reviews/images?treeId=${treeId}`);
+  const { data, isError } = useApiQuery<IReviewImages>(`v1/reviews/images?treeId=${treeId}`);
   const navigate = useNavigate();
 
   if (isError) {
-    throw new HTTPError(`리뷰 정보를 불러오는데 오류가 발생했습니다. ${error}`);
+    throw new HTTPError(`리뷰 정보를 불러오는데 오류가 발생했습니다`);
   }
 
   const handleReviewPhoto = (reviewId: number) => {

--- a/src/pages/TreeInfoPage/components/VisitorReviewList/index.tsx
+++ b/src/pages/TreeInfoPage/components/VisitorReviewList/index.tsx
@@ -20,7 +20,7 @@ const VisitorReviewList = ({ treeId, treeInfo }: IProps) => {
   const navigate = useNavigate();
 
   if (isError) {
-    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다. ${error}`);
+    throw new HTTPError(`트리 정보를 불러오는데 오류가 발생했습니다.`);
   }
 
   const findTagId = (comment: string): TagId => {

--- a/src/pages/TreeInfoPage/components/style.ts
+++ b/src/pages/TreeInfoPage/components/style.ts
@@ -126,7 +126,7 @@ export const ReviewCard = styled.article<ReviewCardProps>`
   margin: 1.6rem 2.4rem;
   display: ${(props) => (props.hasPhotoReview ? 'grid' : 'block')};
   grid-template-columns: ${(props) => (props.hasPhotoReview ? '1fr 11.6rem' : 'none')};
-  grid-column-gap: ${(props) => (props.hasPhotoReview ? '4.2rem' : 'none')};
+  /* grid-column-gap: ${(props) => (props.hasPhotoReview ? '4.2rem' : 'none')}; */
 `;
 
 export const Profile = styled.div`

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -19,6 +19,7 @@ import RegistReviewPage from 'pages/MyReviewPage';
 import ReviewRegistAndEditPage from 'pages/ReviewRegistAndEditPage';
 import useUser from 'hooks/useUser';
 import Unauthorized from 'components/Guides/Unauthorized';
+import SessionExpiredGuide from 'components/Guides/SessionExpired';
 
 const Router = () => {
   const { isLogin } = useUser();
@@ -106,6 +107,11 @@ const Router = () => {
     element: <ErrorPage />,
   };
 
+  const loginExpiredRoute: RouteObject = {
+    path: PATH.sessionExpired,
+    element: <SessionExpiredGuide />,
+  };
+
   const routes = [
     landingRoute,
     mainRoute,
@@ -115,6 +121,7 @@ const Router = () => {
     loginRedirectRoute,
     myRoute,
     NotFoundRoute,
+    loginExpiredRoute,
   ];
 
   return useRoutes(routes);

--- a/src/utils/getPath.ts
+++ b/src/utils/getPath.ts
@@ -37,6 +37,8 @@ const PATH_DATABASE = {
     registedTrees: `/${PATH.myPage.root}/${PATH.myPage.children.registedTrees}`,
     registedReviews: `/${PATH.myPage.root}/${PATH.myPage.children.registedReviews}`,
   },
+
+  sessionExpired: `/${PATH.sessionExpired}`,
 };
 
 type PATH_DATABASE = typeof PATH_DATABASE;


### PR DESCRIPTION
## ⭐ 개요
0.1.3 베타버전에 발생한 오류들을 해결했습니다.

### 로그인 관련 오류 해결
사용자의 로그인 상태 관련해 오류 발생하던 부분 해결했습니다.

- 로그인 이후 마이페이지에 진입시 로그인 이후 가능한 페이지라는 가이드 렌더링 되던 오류 해결
- 로그인 세션 만료시 사용자가 로그인 페이지로 이동할 수 있도록 가이드

### API 요청 오류 해결
어떤 엔드포인트로 요청으로 보내도 500 에러가 반환되던 오류를 해결했습니다.
Access Token 관련 로직을 수정했습니다.

### 트리 상세 페이지 태그 디자인 오류
리뷰에 사진이 존재하는 경우에 태그의 디자인이 어긋나던 부분을 수정했습니다.

<img width="403" alt="image" src="https://github.com/whereismytree/frontend/assets/126222927/a440e391-c6a9-4800-8d84-187643d37221">

